### PR TITLE
Fix DisplayListDrawGlyphRecorder Haiku implementation

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawGlyphsRecorderHaiku.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawGlyphsRecorderHaiku.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ DrawGlyphsRecorder::DrawGlyphsRecorder(Recorder& owner, DrawGlyphsDeconstruction
 
 void DrawGlyphsRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& startPoint, FontSmoothingMode smoothingMode)
 {
-    m_owner.append<DrawGlyphs>(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
+    m_owner.appendDrawGlyphsItemWithCachedFont(font, glyphs, advances, numGlyphs, startPoint, smoothingMode);
 }
 
 } // namespace DisplayList


### PR DESCRIPTION
Do the same thing as Harfbuzz and Windows implementations.

This class allows the CoreText (Apple) version to convert the text
rendering to vectors and cache that. Then they don't need to redraw all
the text when scrolling or otherwise redrawing the page. On other
platofrms, this optimization is not used and we just take note to redraw
the text in the "recording".

It seems the Haiku implementation was not recording this in the correct
way and so the recording would not work.

This should fix #17066 (not sure because I don't reproduce the issue on
my machine)